### PR TITLE
Add Workflows to the Project

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,3 @@
 BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - { name: "Windows MSVC", os: windows-latest, cc: "cl", cxx: "cl" }
+          - { name: "Windows gcc", os: windows-latest, cc: "gcc", cxx: "g++" }
           - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc", cxx: "g++" }
           - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++" }
         build-configuration: [ Debug, Release ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 # It builds the project on multiple operating systems (Ubuntu, Windows, and macOS)
 
+name: Build Project
+
 on:
   pull_request:
     branches:
@@ -12,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        build-configuration: [ Debug, Release ]
 
     steps:
       - name: Checkout repository
@@ -22,10 +25,4 @@ jobs:
       - name: Build Project
         uses: threeal/cmake-action@v2.1.0
         with:
-          run-build: false
-
-      - name: Build Debug
-        run: cmake --build debug --config Debug
-
-      - name: Build Release
-        run: cmake --build release --config Release
+          args: -DCMAKE_BUILD_TYPE=${{ matrix.build-configuration }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   debug:
-    name: Debug Build
+    name: Build
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# It builds the project on multiple operating systems (Ubuntu, Windows, and macOS)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  debug:
+    name: Debug Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build Project
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          run-build: false
+
+      - name: Build Debug
+        run: cmake --build debug --config Debug
+
+      - name: Build Release
+        run: cmake --build release --config Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,13 @@ on:
 jobs:
   debug:
     name: Debug Build
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        config:
+          - { name: "Windows MSVC", os: windows-latest, cc: "cl", cxx: "cl" }
+          - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc", cxx: "g++" }
+          - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++" }
         build-configuration: [ Debug, Release ]
 
     steps:
@@ -22,7 +25,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup Ninja
+        uses: ashutoshvarma/setup-ninja@master
+
       - name: Build Project
         uses: threeal/cmake-action@v2.1.0
         with:
-          args: -DCMAKE_BUILD_TYPE=${{ matrix.build-configuration }}
+          args: -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build-configuration }}
+          c-compiler: ${{ matrix.config.cc }}
+          cxx-compiler: ${{ matrix.config.cxx }}

--- a/.github/workflows/clang-format-dispatch.yml
+++ b/.github/workflows/clang-format-dispatch.yml
@@ -1,0 +1,33 @@
+# This workflow should only be run by administrators
+
+name: ClangFormat correction
+on:
+  workflow_dispatch:
+
+jobs:
+  ClangFormat:
+    name: ClangFormat correction
+    runs-on: ubuntu-22.04
+
+    # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+    permissions:
+      contents: write
+
+    steps:
+      # Clone Repo
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Format code
+        #run: clang-format -i **/*.cpp
+        run: find . -type f \( -name '*.c' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec clang-format -i {} \;
+
+      # Commit all changed files back to the repository
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Apply Clang formatting'
+          create_branch: false

--- a/.github/workflows/clang-format-dispatch.yml
+++ b/.github/workflows/clang-format-dispatch.yml
@@ -1,6 +1,7 @@
 # This workflow should only be run by administrators
 
 name: ClangFormat correction
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/clang-format-pr.yml
+++ b/.github/workflows/clang-format-pr.yml
@@ -30,29 +30,5 @@ jobs:
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.15.0
         id: clang-format
-        continue-on-error: true
         with:
           clang-format-version: "20"
-
-      - name: Comment on PR
-        if: steps.clang-format.outcome == 'failure'
-        uses: thollander/actions-comment-pull-request@v3.0.1
-        with:
-          message: |
-            clang-format 20 needs to be run on this PR.
-            If you do not have clang-format installed, the maintainer will run it when merging.
-
-            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          comment-tag: execution
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Comment on PR
-        if: steps.clang-format.outcome != 'failure'
-        uses: thollander/actions-comment-pull-request@v3.0.1
-        with:
-          message: |
-            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          create-if-not-exists: false
-          comment-tag: execution
-          mode: delete
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format-pr.yml
+++ b/.github/workflows/clang-format-pr.yml
@@ -5,7 +5,7 @@
 # executes no shell script nor runs make.
 # Read this before editing: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
-name: Clang-Format
+name: ClangFormat check
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,11 +9,12 @@ name: Clang-Format
 on:
   pull_request_target:
     branches:
-      - "master"
+      - "main"
     paths:
       - "**.cpp"
       - "**.h"
 
+# needed for automatic comment in pr
 permissions:
   pull-requests: write
 
@@ -27,33 +28,31 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run clang-format style check
-        uses: jidicula/clang-format-action@f62da5e3d3a2d88ff364771d9d938773a618ab5e # @v4.11.0
+        uses: jidicula/clang-format-action@v4.15.0
         id: clang-format
         continue-on-error: true
         with:
-          clang-format-version: "18"
-          exclude-regex: "incbin"
+          clang-format-version: "20"
 
       - name: Comment on PR
         if: steps.clang-format.outcome == 'failure'
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # @v2.5.0
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           message: |
-            clang-format 18 needs to be run on this PR.
+            clang-format 20 needs to be run on this PR.
             If you do not have clang-format installed, the maintainer will run it when merging.
-            For the exact version please see https://packages.ubuntu.com/noble/clang-format-18.
 
             _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          comment_tag: execution
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: execution
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR
         if: steps.clang-format.outcome != 'failure'
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # @v2.5.0
+        uses: thollander/actions-comment-pull-request@v3.0.1
         with:
           message: |
             _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          create_if_not_exists: false
-          comment_tag: execution
+          create-if-not-exists: false
+          comment-tag: execution
           mode: delete
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,59 @@
+# This workflow is from https://github.com/official-stockfish/Stockfish/blob/master/.github/workflows/clang-format.yml#L23
+
+# This workflow will run clang-format and comment on the PR.
+# Because of security reasons, it is crucial that this workflow
+# executes no shell script nor runs make.
+# Read this before editing: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+name: Clang-Format
+on:
+  pull_request_target:
+    branches:
+      - "master"
+    paths:
+      - "**.cpp"
+      - "**.h"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  Clang-Format:
+    name: Clang-Format
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run clang-format style check
+        uses: jidicula/clang-format-action@f62da5e3d3a2d88ff364771d9d938773a618ab5e # @v4.11.0
+        id: clang-format
+        continue-on-error: true
+        with:
+          clang-format-version: "18"
+          exclude-regex: "incbin"
+
+      - name: Comment on PR
+        if: steps.clang-format.outcome == 'failure'
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # @v2.5.0
+        with:
+          message: |
+            clang-format 18 needs to be run on this PR.
+            If you do not have clang-format installed, the maintainer will run it when merging.
+            For the exact version please see https://packages.ubuntu.com/noble/clang-format-18.
+
+            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
+          comment_tag: execution
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        if: steps.clang-format.outcome != 'failure'
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # @v2.5.0
+        with:
+          message: |
+            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
+          create_if_not_exists: false
+          comment_tag: execution
+          mode: delete
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,4 +1,4 @@
-# This workflow runs when a tag is pushed to the repository.
+# This workflow runs when a tag is pushed to the repository point to the main branch.
 # It builds the project on multiple operating systems (Ubuntu, Windows, and macOS) and
 # creates a pre-release.
 
@@ -12,10 +12,7 @@ on:
 jobs:
   release:
     name: Create Release
-    needs: build
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,11 +30,12 @@ jobs:
 
   build:
     name: Build Project
+    needs: release
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
         config:
-          - { name: "Windows MSVC", os: windows-latest, cc: "cl", cxx: "cl" }
+          - { name: "Windows gcc", os: windows-latest, cc: "gcc", cxx: "g++" }
           - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc", cxx: "g++" }
           - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++" }
         build-configuration: [ Release ]
@@ -63,14 +61,11 @@ jobs:
         with:
           type: 'zip'
           path: 'build'
-          filename: 'build.zip'
+          filename: '${{ matrix.config.os}}-build.zip'
 
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: alexellis/upload-assets@0.4.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build.zip
-          asset_name: ${{ matrix.config.os }}.zip
-          asset_content_type: application/zip
+         asset_paths: '["${{ matrix.config.os}}-build.zip"]'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -2,6 +2,8 @@
 # It builds the project on multiple operating systems (Ubuntu, Windows, and macOS) and
 # creates a pre-release.
 
+name: Create Release
+
 on:
   push:
     tags:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -10,38 +10,8 @@ on:
       - 'v*'
 
 jobs:
-  build:
-    name: Build Project
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build Project
-        uses: threeal/cmake-action@v2.1.0
-        with:
-          run-build: false
-
-      - name: Build Release
-        run: cmake --build build --config Release
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: build/
-          asset_name: build-${{ matrix.os }}
-          asset_content_type: application/zip
-
   release:
+    name: Create Release
     needs: build
     runs-on: ubuntu-latest
     outputs:
@@ -60,3 +30,47 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: true
+
+  build:
+    name: Build Project
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { name: "Windows MSVC", os: windows-latest, cc: "cl", cxx: "cl" }
+          - { name: "Ubuntu gcc", os: ubuntu-latest, cc: "gcc", cxx: "g++" }
+          - { name: "MacOS clang", os: macos-latest, cc: "clang", cxx: "clang++" }
+        build-configuration: [ Release ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Ninja
+        uses: ashutoshvarma/setup-ninja@master
+
+      - name: Build Project
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          args: -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build-configuration }}
+          c-compiler: ${{ matrix.config.cc }}
+          cxx-compiler: ${{ matrix.config.cxx }}
+
+      - name: Compress Build Directory
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          path: 'build'
+          filename: 'build.zip'
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build.zip
+          asset_name: ${{ matrix.config.os }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,60 @@
+# This workflow runs when a tag is pushed to the repository.
+# It builds the project on multiple operating systems (Ubuntu, Windows, and macOS) and
+# creates a pre-release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build Project
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build Project
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          run-build: false
+
+      - name: Build Release
+        run: cmake --build build --config Release
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: build/
+          asset_name: build-${{ matrix.os }}
+          asset_content_type: application/zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: true


### PR DESCRIPTION
### Describe your changes

This pull request includes several changes to the GitHub workflows and configuration files to improve the build and formatting processes. The most important changes include the addition of workflows for building the project, formatting code, and creating releases, as well as the introduction of a new `.clang-format` configuration.

### GitHub workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R36): Added a workflow to build the project on multiple operating systems (Ubuntu, Windows, and macOS).
* [`.github/workflows/release-tag.yml`](diffhunk://#diff-78ca2a162e43bc38ce9cf9eee54d1bfa9b15678fcc153cc554779bbb854b3a81R1-R71): Added a workflow to create a pre-release when a tag is pushed to the repository, including building the project on multiple operating systems and uploading the build artifacts.

### Code formatting:

* [`.github/workflows/clang-format-dispatch.yml`](diffhunk://#diff-d76de22c74870fc2997d557e90e03ab041a74534a9bb4fc02865e08af1fe7598R1-R34): Added a workflow to apply Clang formatting corrections, which can only be run by administrators.
* [`.github/workflows/clang-format-pr.yml`](diffhunk://#diff-0383c5f401c59c21a0c648c8f9d8356a39e3eb3b5fe39399e8ab5db623769be5R1-R34): Added a workflow to check Clang formatting on pull requests and comment on the PR with the results.
* [`.clang-format`](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2R1-R3): Introduced a new Clang format configuration file based on Google's style, with specific settings for indentation width and column limit.
### Tested platforms
- [ ] Windows (x86/32-Bit)
- [ ] Windows (64-Bit)
- [ ] Ubuntu (20.04 LTS or above)
- [ ] macOS (Apple Silicon)
- [X] GitHub Actions